### PR TITLE
500エラーの解消,flash文をtags.html内に表示

### DIFF
--- a/app.py
+++ b/app.py
@@ -417,8 +417,9 @@ def tag_channel(tid):
     if channels:
         return render_template('index.html', tag_name=tag_name, channels=channels, uid=uid)
     else:
-        flash('まだチャンネルは登録されていません')
-        return render_template('index.html', tag_name=tag_name, uid=uid)
+        flash(tag_name + 'のタグにチャンネルは登録されていません')
+        return redirect('/tags')
+
 
 # タグ追加&紐付け
 @app.route('/link_tag', methods=['POST'])

--- a/static/css/registration.css
+++ b/static/css/registration.css
@@ -133,4 +133,5 @@
   color: red;
   background-color: yellow;
   border: 3px solid red;
+  padding: 0px;
 }

--- a/templates/tags.html
+++ b/templates/tags.html
@@ -9,6 +9,16 @@
     <div class="tag-title">
       <h1>タグ一覧</h1>
     </div>
+      {# フラッシュメッセージ確認用 #}
+      {% with messages = get_flashed_messages() %}
+        {% if messages %}
+          <ul class="flashes">
+            {% for message in messages %}
+              <li>{{ message }}</li>
+            {% endfor %}
+          </ul>
+        {% endif %}
+      {% endwith %}
     <ul class="tag-box">
       {% for tag in tags %}
       <li><a href="{{ url_for('tag_channel', tid=tag.id) }}">{{ tag.name }}</a></li>


### PR DESCRIPTION
[目的]
- チャンネルが紐づいていないタグを選択時、500エラーが表示される問題の解消
    - チャンネルが紐付いていないタグ選択時、redirectでflash文をtags.html内に表示
    - flashのcssのpaddingを調整

[実装の概要]
- app.py) tag_channel関数の選択されたタグにチャンネルが紐付いていない場合の処理を変更
    - render_template -> redirect('/tags')

[レビューして欲しいところ]
- flash文は正常に表示されているか
- 500エラーは起きないか

[不安に思っていること]

[保留してること]

[関連]

@knks @kumatora2524 

close #115 