### PR TITLE
チャット画面ヘッダー調整

### DIFF
--- a/static/css/detail.css
+++ b/static/css/detail.css
@@ -36,14 +36,30 @@
   border-radius: 8px;
 }
 
+.tag-accordion-title {
+  background-color: rgb(207, 229, 249);
+  height: 50px;
+  width: calc(100vw - 70px);
+  position: fixed;
+  top: 8vh;
+  z-index: 2;
+}
+
+.tag-accordion-title p {
+  padding-left: 15px;
+  font-size: medium;
+  text-decoration: underline;
+  cursor: pointer;
+}
+
 #header-tag-list {
   background-color: rgb(207, 229, 249);
   height: 0;
   width: calc(100vw - 70px);
   position: fixed;
-  top: 8vh;
+  top: calc(8vh + 50px);
   color: black;
-  font-weight: 600;
+  font-weight: 100;
   display: flex;
   flex-wrap: wrap;
   align-items: center;
@@ -51,6 +67,7 @@
   padding-left: 20px;
   z-index: 2;
   box-shadow: 0px 10px 10px 0px black;
+  box-sizing: border-box;
 }
 
 .tag-list-loop {
@@ -58,13 +75,41 @@
   align-items: center;
   padding: 2px;
   border-radius: 10px;
-  background-color: blue;
-  margin-right: 5px;
-  flex-basis: calc(30% - 20px);
+  background-color: rgb(207, 229, 249);
+  margin-right: 0;
+  /*flex-basis: calc(30% - 20px);*/
 }
 
 .tag-list-loop:last-of-type {
   margin-right: 0;
+}
+
+.ch-tag-delete-btn button {
+  color: red;
+  font-weight: 600;
+}
+
+.tag-delete-btn {
+  width: 3px;
+  height: 3px;
+  border: 1px solid #333;
+  border-radius: 0;
+  padding: 8px;
+  background-color: red;
+}
+
+.tag-delete-btn::before, .tag-delete-btn::after {
+  content: "";
+  display: block;
+  position: absolute;
+  width: 2%;
+  height: 2px;
+  background-color: white;
+  transform: translate(-50%, -50%) rotate(45deg);
+}
+
+.tag-delete-btn::after {
+  transform: translate(-50%, -50%) rotate(-45deg);
 }
 
 #chatroom-name {
@@ -95,7 +140,7 @@
 #message-area {
   min-height: 100vh;
   width: 100%;
-  padding-top: calc(8vh + 10px);
+  padding-top: calc(8vh + 60px);
   padding-right: 20px;
   padding-bottom: calc(20vh + 10px);
   padding-left: 20px;

--- a/static/css/detail.css
+++ b/static/css/detail.css
@@ -30,88 +30,6 @@
   box-shadow: 0px 10px 10px 0px black;
 }
 
-.ch-tag-btn {
-  background-color: black;
-  color: white;
-  border-radius: 8px;
-}
-
-.tag-accordion-title {
-  background-color: rgb(207, 229, 249);
-  height: 50px;
-  width: calc(100vw - 70px);
-  position: fixed;
-  top: 8vh;
-  z-index: 2;
-}
-
-.tag-accordion-title p {
-  padding-left: 15px;
-  font-size: medium;
-  text-decoration: underline;
-  cursor: pointer;
-}
-
-#header-tag-list {
-  background-color: rgb(207, 229, 249);
-  height: 0;
-  width: calc(100vw - 70px);
-  position: fixed;
-  top: calc(8vh + 50px);
-  color: black;
-  font-weight: 100;
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  gap: 2rem;
-  padding-left: 20px;
-  z-index: 2;
-  box-shadow: 0px 10px 10px 0px black;
-  box-sizing: border-box;
-}
-
-.tag-list-loop {
-  display: inline-flex;
-  align-items: center;
-  padding: 2px;
-  border-radius: 10px;
-  background-color: rgb(207, 229, 249);
-  margin-right: 0;
-  /*flex-basis: calc(30% - 20px);*/
-}
-
-.tag-list-loop:last-of-type {
-  margin-right: 0;
-}
-
-.ch-tag-delete-btn button {
-  color: red;
-  font-weight: 600;
-}
-
-.tag-delete-btn {
-  width: 3px;
-  height: 3px;
-  border: 1px solid #333;
-  border-radius: 0;
-  padding: 8px;
-  background-color: red;
-}
-
-.tag-delete-btn::before, .tag-delete-btn::after {
-  content: "";
-  display: block;
-  position: absolute;
-  width: 2%;
-  height: 2px;
-  background-color: white;
-  transform: translate(-50%, -50%) rotate(45deg);
-}
-
-.tag-delete-btn::after {
-  transform: translate(-50%, -50%) rotate(-45deg);
-}
-
 #chatroom-name {
   font-size: larger;
 }
@@ -135,12 +53,92 @@
   background-color: rgb(206, 27, 57);
 }
 
+.ch-tag-btn {
+  background-color: black;
+  color: white;
+  border-radius: 8px;
+}
+
+.tag-accordion-title {
+  background-color: rgb(207, 229, 249);
+  height: 30px;
+  width: calc(100vw - 70px);
+  position: fixed;
+  top: 8vh;
+  z-index: 2;
+}
+
+.tag-accordion-title p {
+  padding-left: 15px;
+  font-size: small;
+  /* text-decoration: underline; */
+  /* cursor: pointer; */
+}
+
+#header-tag-list {
+  background-color: rgb(207, 229, 249);
+  height: 0px;
+  width: calc(100vw - 70px);
+  position: fixed;
+  top: calc(8vh + 30px);
+  color: black;
+  font-weight: 100;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 1rem;
+  padding-left: 20px;
+  z-index: 2;
+  box-shadow: 0px 10px 10px 0px black;
+}
+
+.tag-list-loop {
+  display: inline-flex;
+  align-items: center;
+  padding: 2px;
+  margin-top: 0;
+  margin-right: 0;
+}
+
+.tag-list-loop a {
+  font-size: small;
+  text-decoration: underline;
+}
+
+.tag-list-loop:last-of-type {
+  margin-right: 0;
+}
+
+.tag-delete-btn {
+  width: 3px;
+  height: 3px;
+  border: 1px solid #333;
+  border-radius: 0;
+  padding: 6px;
+  background-color: red;
+  margin-left: 4px;
+}
+
+.tag-delete-btn::before, .tag-delete-btn::after {
+  content: "";
+  display: block;
+  position: absolute;
+  width: 12px;
+  height: 2px;
+  background-color: white;
+  transform: translate(-50%, -50%) rotate(45deg);
+}
+
+.tag-delete-btn::after {
+  transform: translate(-50%, -50%) rotate(-45deg);
+}
+
 /* メッセージエリア */
 
 #message-area {
   min-height: 100vh;
   width: 100%;
-  padding-top: calc(8vh + 60px);
+  padding-top: calc(8vh + 100px);
   padding-right: 20px;
   padding-bottom: calc(20vh + 10px);
   padding-left: 20px;
@@ -206,28 +204,6 @@
   color: rgba(255, 255, 255, 0.885);
 }
 
-/*.box-left:before {
-  position: absolute;
-  top: 3px;
-  left: 3px;
-  width: 100%;
-  height: 100%;
-  border-radius: 10px;
-  border: 2px solid #333;
-  content: "";
-}
-
-.box-right:before {
-  position: absolute;
-  top: 3px;
-  right: 3px;
-  width: 100%;
-  height: 100%;
-  border-radius: 10px;
-  border: 2px solid #333;
-  content: "";
-}*/
-
 /* ========================================================== */
 
 .typing-box-wrapper {
@@ -235,9 +211,7 @@
   bottom: 0;
   width: calc(100vw - 70px);
   height: 15vh;
-  /*background-color: rgba(211, 211, 211, 0.75);*/
   background-size: contain;
-  /*border-top: 3px solid black;*/
   display: flex;
   align-items: center;
   justify-content: start;

--- a/static/css/detail.css
+++ b/static/css/detail.css
@@ -36,6 +36,23 @@
   border-radius: 8px;
 }
 
+.header-tag-list {
+  display: block;
+}
+
+.tag-list-loop {
+  display: inline-flex;
+  align-items: center;
+  padding: 5px;
+  border-radius: 10px;
+  background-color: blue;
+  margin-right: 10px;
+}
+
+.tag-list-loop:last-of-type {
+  margin-right: 0;
+}
+
 #chatroom-name {
   font-size: larger;
 }

--- a/static/css/detail.css
+++ b/static/css/detail.css
@@ -36,17 +36,31 @@
   border-radius: 8px;
 }
 
-.header-tag-list {
-  display: block;
+#header-tag-list {
+  background-color: rgb(207, 229, 249);
+  height: 0;
+  width: calc(100vw - 70px);
+  position: fixed;
+  top: 8vh;
+  color: black;
+  font-weight: 600;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 2rem;
+  padding-left: 20px;
+  z-index: 2;
+  box-shadow: 0px 10px 10px 0px black;
 }
 
 .tag-list-loop {
   display: inline-flex;
   align-items: center;
-  padding: 5px;
+  padding: 2px;
   border-radius: 10px;
   background-color: blue;
-  margin-right: 10px;
+  margin-right: 5px;
+  flex-basis: calc(30% - 20px);
 }
 
 .tag-list-loop:last-of-type {

--- a/static/js/delete-channel.js
+++ b/static/js/delete-channel.js
@@ -15,3 +15,8 @@ deleteButton.addEventListener("click", deleteChannel);
 deletePageButtonClose.addEventListener("click", () => {
   modalClose("delete");
 });
+
+// 削除確認モーダルでの削除実行コード
+const confirmationButtonLink = document.getElementById("delete-confirm-link"); // id取得（aタグ）
+const url = `/delete/${channel.id}`; // urlを作成
+confirmationButtonLink.setAttribute("href", url); // urlを取得id（aタグ）のhref属性に設定

--- a/static/js/delete-channel.js
+++ b/static/js/delete-channel.js
@@ -1,0 +1,17 @@
+const deleteButton = document.getElementById("channel-delete");
+const deleteChannelModal = document.getElementById("delete-channel-modal");
+const deletePageButtonClose = document.getElementById("delete-page-close-btn");
+const deleteChannelConfirmBtn = document.querySelector("#delete-channel-confirmation-btn");
+
+const deleteChannel = () => {
+  if (uid !== channel.uid) {
+    return;
+  } else {
+    modalOpen("delete");
+  }
+};
+deleteButton.addEventListener("click", deleteChannel);
+
+deletePageButtonClose.addEventListener("click", () => {
+  modalClose("delete");
+});

--- a/static/js/delete-channel.js
+++ b/static/js/delete-channel.js
@@ -20,3 +20,7 @@ deletePageButtonClose.addEventListener("click", () => {
 const confirmationButtonLink = document.getElementById("delete-confirm-link"); // id取得（aタグ）
 const url = `/delete/${channel.id}`; // urlを作成
 confirmationButtonLink.setAttribute("href", url); // urlを取得id（aタグ）のhref属性に設定
+
+// モーダルコンテンツ以外がクリックされた時
+addEventListener("click", outsideClose);
+function outsideClose(e) { if (e.target == deleteChannelModal) { deleteChannelModal.style.display = "none"; } }

--- a/static/js/detail.js
+++ b/static/js/detail.js
@@ -7,7 +7,7 @@ function calculateHeaderHeight() {
   const tagCount = chatHeader.childElementCount; // タグの表示数取得
   const headerWidth = chatHeader.offsetWidth; // ヘッダーの幅取得
   const tagWidth = chatHeader.firstElementChild.offsetWidth; // タグの幅取得
-  const tagHeight = 120; // 一行あたりのタグ表示の高さを設定
+  const tagHeight = 40; // 一行あたりのタグ表示の高さを設定
   const maxTagPerRow = Math.floor(headerWidth / tagWidth); // 各行に表示できるタグの最大数
   const rowCount = Math.ceil(tagCount / maxTagPerRow); // タグ表示の行数
   const headerHeight = rowCount * tagHeight; // ヘッダー高さ

--- a/static/js/detail.js
+++ b/static/js/detail.js
@@ -1,10 +1,15 @@
 // 親要素の取得
-const chatHeader = document.getElementById('chat-header');
+const chatHeader = document.getElementById('header-tag-list');
 
-// 子要素の数に応じた高さを計算する関数
+// タグの表示数に応じたヘッダー高さを計算する関数
 function calculateHeaderHeight() {
-  const childCount = chatHeader.childElementCount;
-  const headerHeight = 50 + (childCount * 10); // この計算式は適宜変更する
+  const tagCount = chatHeader.childElementCount; // タグの表示数取得
+  const headerWidth = chatHeader.offsetWidth; // ヘッダーの幅取得
+  const tagWidth = chatHeader.firstElementChild.offsetWidth; // タグの幅取得
+  const tagHeight = 120; // 一行あたりのタグ表示の高さを設定
+  const maxTagPerRow = Math.floor(headerWidth / tagWidth); // 各行に表示できるタグの最大数
+  const rowCount = Math.ceil(tagCount / maxTagPerRow); // タグ表示の行数
+  const headerHeight = rowCount * tagHeight; // ヘッダー高さ
   return headerHeight;
 }
 

--- a/static/js/detail.js
+++ b/static/js/detail.js
@@ -42,30 +42,7 @@ window.addEventListener('resize', function() {
   }
 });
 
-// タグ一覧のアコーディオンメニュー化
-//const accordionItems = document.querySelectorAll(".chat-box");
-//accordionItems.forEach((item) => {
-  //const header = item.querySelector(".tag-accordion-title");
-  //header.addEventListener("click", () => {
-    //item.classList.toggle("active");
-  //});
-//});
-
 /*
-// タグ一覧のアコーディオンメニュー化
-document.addEventListener('DOMContentLoaded', function() {
-  var title = document.querySelector('.tag-accordion-title');
-  var list = document.getElementById('header-tag-list');
-  title.addEventListener('click', function() {
-    if (list.style.display === 'none') {
-      list.style.display = 'block';
-    } else {
-      list.style.display = 'none';
-    }
-  });
-});
-*/
-
 // タグ一覧のアコーディオンメニュー化
 document.addEventListener('DOMContentLoaded', function() {
   const list = document.getElementById('header-tag-list');
@@ -73,31 +50,9 @@ document.addEventListener('DOMContentLoaded', function() {
   const title = document.querySelector('.tag-accordion-title');
   title.addEventListener('click', function() {
     if (list.style.display === 'none') {
-      //list.style.display = 'block';
       showHeader();
     } else {
-      //list.style.display = 'none';
       hideHeader();
-    }
-  });
-});
-
-/*
-//タグ一覧のアコーディオンメニュー化
-document.addEventListener('DOMContentLoaded', function() {
-  var list = document.getElementById('header-tag-list');
-  list.style.display = 'none'; // 初期状態で非表示にする
-  var title = document.querySelector('.tag-accordion-title');
-  title.addEventListener('click', function() {
-    if (list.style.display === 'none') {
-      // アコーディオンメニューを開くときに、flex-basisを再設定する
-      var items = list.querySelectorAll('.tag-list-loop');
-      for (var i = 0; i < items.length; i++) {
-        items[i].style.flexBasis = 'calc(30% - 20px)';
-      }
-      list.style.display = 'block';
-    } else {
-      list.style.display = 'none';
     }
   });
 });

--- a/static/js/detail.js
+++ b/static/js/detail.js
@@ -3,6 +3,7 @@ const chatHeader = document.getElementById('header-tag-list');
 
 // タグの表示数に応じたヘッダー高さを計算する関数
 function calculateHeaderHeight() {
+  const chatHeader = document.getElementById('header-tag-list');
   const tagCount = chatHeader.childElementCount; // タグの表示数取得
   const headerWidth = chatHeader.offsetWidth; // ヘッダーの幅取得
   const tagWidth = chatHeader.firstElementChild.offsetWidth; // タグの幅取得
@@ -23,3 +24,81 @@ updateHeaderHeight();
 
 // スクロール時にヘッダーの高さを更新する
 window.addEventListener('scroll', updateHeaderHeight);
+
+// スクロール時だけでなく、タグ一覧が表示される度にヘッダーの高さを更新する
+function showHeader() {
+  chatHeader.style.display = 'block';
+  updateHeaderHeight();
+}
+
+function hideHeader() {
+  chatHeader.style.display = 'none';
+}
+
+// ウィンドウサイズが変更されたときにもヘッダーの高さを更新する
+window.addEventListener('resize', function() {
+  if (chatHeader.style.display === 'block') {
+    updateHeaderHeight();
+  }
+});
+
+// タグ一覧のアコーディオンメニュー化
+//const accordionItems = document.querySelectorAll(".chat-box");
+//accordionItems.forEach((item) => {
+  //const header = item.querySelector(".tag-accordion-title");
+  //header.addEventListener("click", () => {
+    //item.classList.toggle("active");
+  //});
+//});
+
+/*
+// タグ一覧のアコーディオンメニュー化
+document.addEventListener('DOMContentLoaded', function() {
+  var title = document.querySelector('.tag-accordion-title');
+  var list = document.getElementById('header-tag-list');
+  title.addEventListener('click', function() {
+    if (list.style.display === 'none') {
+      list.style.display = 'block';
+    } else {
+      list.style.display = 'none';
+    }
+  });
+});
+*/
+
+// タグ一覧のアコーディオンメニュー化
+document.addEventListener('DOMContentLoaded', function() {
+  const list = document.getElementById('header-tag-list');
+  list.style.display = 'none'; // 初期状態で非表示にする
+  const title = document.querySelector('.tag-accordion-title');
+  title.addEventListener('click', function() {
+    if (list.style.display === 'none') {
+      //list.style.display = 'block';
+      showHeader();
+    } else {
+      //list.style.display = 'none';
+      hideHeader();
+    }
+  });
+});
+
+/*
+//タグ一覧のアコーディオンメニュー化
+document.addEventListener('DOMContentLoaded', function() {
+  var list = document.getElementById('header-tag-list');
+  list.style.display = 'none'; // 初期状態で非表示にする
+  var title = document.querySelector('.tag-accordion-title');
+  title.addEventListener('click', function() {
+    if (list.style.display === 'none') {
+      // アコーディオンメニューを開くときに、flex-basisを再設定する
+      var items = list.querySelectorAll('.tag-list-loop');
+      for (var i = 0; i < items.length; i++) {
+        items[i].style.flexBasis = 'calc(30% - 20px)';
+      }
+      list.style.display = 'block';
+    } else {
+      list.style.display = 'none';
+    }
+  });
+});
+*/

--- a/static/js/detail.js
+++ b/static/js/detail.js
@@ -1,0 +1,20 @@
+// 親要素の取得
+const chatHeader = document.getElementById('chat-header');
+
+// 子要素の数に応じた高さを計算する関数
+function calculateHeaderHeight() {
+  const childCount = chatHeader.childElementCount;
+  const headerHeight = 50 + (childCount * 10); // この計算式は適宜変更する
+  return headerHeight;
+}
+
+// スクロール時にヘッダーの高さを更新する関数
+function updateHeaderHeight() {
+  chatHeader.style.height = calculateHeaderHeight() + 'px';
+}
+
+// 初期化時にヘッダーの高さを設定する
+updateHeaderHeight();
+
+// スクロール時にヘッダーの高さを更新する
+window.addEventListener('scroll', updateHeaderHeight);

--- a/static/js/modal.js
+++ b/static/js/modal.js
@@ -1,14 +1,14 @@
 // モーダルを表示させる
 const addChannelModal = document.querySelector("#add-channel-modal");
-const deleteChannelModal = document.querySelector("#delete-channel-modal");
+//const deleteChannelModal = document.querySelector("#delete-channel-modal");
 
 const addPageButtonClose = document.querySelector("#add-page-close-btn");
-const deletePageButtonClose = document.querySelector("#delete-page-close-btn");
+//const deletePageButtonClose = document.querySelector("#delete-page-close-btn");
 
 const addChannelBtn = document.querySelector("#add-channel-btn");
 
 const addChannelConfirmBtn = document.querySelector("#add-channel-confirmation-btn");
-const deleteChannelConfirmBtn = document.querySelector("#delete-channel-confirmation-btn");
+//const deleteChannelConfirmBtn = document.querySelector("#delete-channel-confirmation-btn");
 
 // モーダルを開く
 // <button id="add-channel-btn">チャンネル追加</button>ボタンがクリックされた時
@@ -30,9 +30,11 @@ function modalOpen(mode) {
 addPageButtonClose.addEventListener("click", () => {
   modalClose("add");
 });
+/*
 deletePageButtonClose.addEventListener("click", () => {
   modalClose("delete");
 });
+*/
 
 function modalClose(mode) {
   if (mode === "add") {
@@ -43,7 +45,7 @@ function modalClose(mode) {
     updateChannelModal.style.display = "none";
   }
 }
-
+/*
 // モーダルコンテンツ以外がクリックされた時
 addEventListener("click", outsideClose);
 function outsideClose(e) {
@@ -51,5 +53,14 @@ function outsideClose(e) {
     addChannelModal.style.display = "none";
   } else if (e.target == deleteChannelModal) {
     deleteChannelModal.style.display = "none";
+  }
+}
+*/
+
+// モーダルコンテンツ以外がクリックされた時
+addEventListener("click", outsideClose);
+function outsideClose(e) {
+  if (e.target == addChannelModal) {
+    addChannelModal.style.display = "none";
   }
 }

--- a/static/js/update-channel.js
+++ b/static/js/update-channel.js
@@ -1,0 +1,16 @@
+const updateButton = document.getElementById("channel-update");
+const updateChannelModal = document.getElementById("update-channel-modal");
+const updatePageButtonClose = document.getElementById("update-page-close-btn");
+
+const updateChannel = () => {
+  if (uid !== channel.uid) {
+    return;
+  } else {
+    modalOpen("update");
+  }
+};
+updateButton.addEventListener("click", updateChannel);
+
+updatePageButtonClose.addEventListener("click", () => {
+  modalClose("update");
+});

--- a/static/js/update-channel.js
+++ b/static/js/update-channel.js
@@ -14,3 +14,7 @@ updateButton.addEventListener("click", updateChannel);
 updatePageButtonClose.addEventListener("click", () => {
   modalClose("update");
 });
+
+// モーダルコンテンツ以外がクリックされた時
+addEventListener("click", outsideClose);
+function outsideClose(e) { if (e.target == updateChannelModal) { updateChannelModal.style.display = "none"; } }

--- a/templates/detail.html
+++ b/templates/detail.html
@@ -27,6 +27,9 @@
           </div>
         {% endif %}
       </div>
+      <div class="tag-accordion-title">
+        <p>登録タグ一覧</p>
+      </div>
       <div id="header-tag-list">
         {% if channel_tags %}
           {% for channel_tag in channel_tags %}
@@ -36,7 +39,8 @@
             <form class="ch-tag-delete-btn" action="/delete_tag_link" method="POST">
               <input type="hidden" name="cid" value="{{ cid }}">
               <input type="hidden" name="tid" value="{{ channel_tag.id }}">
-              <button type="submit">x</button>
+              {# <button type="submit">x</button> #}
+              <button type="submit" class="tag-delete-btn"></button>
             </form>
           </div>
           {% endfor %}

--- a/templates/detail.html
+++ b/templates/detail.html
@@ -102,6 +102,10 @@
     type="text/javascript"
   ></script>
   <script
+    src="{{url_for('static',filename='js/delete-channel.js')}}"
+    type="text/javascript"
+  ></script>
+  <script
     src="{{url_for('static',filename='js/modal.js')}}"
     type="text/javascript"
   ></script>

--- a/templates/detail.html
+++ b/templates/detail.html
@@ -26,21 +26,21 @@
             </form>
           </div>
         {% endif %}
-        <div class="header-tag-list">
-          {% if channel_tags %}
-            {% for channel_tag in channel_tags %}
-            <div class="tag-list-loop">
-              {% set cid = channel.id %}
-              <a href="{{ url_for('tag_channel', tid=channel_tag.id) }}">{{ channel_tag.name }}</a>
-              <form class="ch-tag-delete-btn" action="/delete_tag_link" method="POST">
-                <input type="hidden" name="cid" value="{{ cid }}">
-                <input type="hidden" name="tid" value="{{ channel_tag.id }}">
-                <button type="submit">x</button>
-              </form>
-            </div>
-            {% endfor %}
-          {% endif %}
-        </div>
+      </div>
+      <div id="header-tag-list">
+        {% if channel_tags %}
+          {% for channel_tag in channel_tags %}
+          <div class="tag-list-loop">
+            {% set cid = channel.id %}
+            <a href="{{ url_for('tag_channel', tid=channel_tag.id) }}">{{ channel_tag.name }}</a>
+            <form class="ch-tag-delete-btn" action="/delete_tag_link" method="POST">
+              <input type="hidden" name="cid" value="{{ cid }}">
+              <input type="hidden" name="tid" value="{{ channel_tag.id }}">
+              <button type="submit">x</button>
+            </form>
+          </div>
+          {% endfor %}
+        {% endif %}
       </div>
       {# チャット部分 #}
       <div id="message-area">

--- a/templates/detail.html
+++ b/templates/detail.html
@@ -18,13 +18,29 @@
           <button id='channel-delete' class="channel-btn ch-delete-btn">削除</button>
           {% include 'modal/delete-confirmation.html' %}
           <div class="channnel-tag">
-            <form class="tag-form" action="#" method="post">
-              <label for="" class="tag-label">登録タグ名:</label>
-              <input type="text" class="tag-input" placeholder="タグ名入力" name="tag" />
+            <form class="tag-form" action="/link_tag" method="POST">
+              <label class="tag-label" for="tag-name">登録タグ名:</label>
+              <input type="text" class="tag-input" name="tag_name" placeholder="タグ名入力">
+              <input type="hidden" name="cid" value="{{ channel.id }}">
               <input type="submit" class="ch-tag-btn" value="タグ登録">
             </form>
           </div>
         {% endif %}
+        <div class="header-tag-list">
+          {% if channel_tags %}
+            {% for channel_tag in channel_tags %}
+            <div class="tag-list-loop">
+              {% set cid = channel.id %}
+              <a href="{{ url_for('tag_channel', tid=channel_tag.id) }}">{{ channel_tag.name }}</a>
+              <form class="ch-tag-delete-btn" action="/delete_tag_link" method="POST">
+                <input type="hidden" name="cid" value="{{ cid }}">
+                <input type="hidden" name="tid" value="{{ channel_tag.id }}">
+                <button type="submit">x</button>
+              </form>
+            </div>
+            {% endfor %}
+          {% endif %}
+        </div>
       </div>
       {# チャット部分 #}
       <div id="message-area">
@@ -83,6 +99,10 @@
   ></script>
   <script
     src="{{url_for('static',filename='js/modal.js')}}"
+    type="text/javascript"
+  ></script>
+  <script
+    src="{{url_for('static',filename='js/detail.js')}}"
     type="text/javascript"
   ></script>
 {% endblock %}

--- a/templates/detail.html
+++ b/templates/detail.html
@@ -36,12 +36,13 @@
           <div class="tag-list-loop">
             {% set cid = channel.id %}
             <a href="{{ url_for('tag_channel', tid=channel_tag.id) }}">{{ channel_tag.name }}</a>
-            <form class="ch-tag-delete-btn" action="/delete_tag_link" method="POST">
-              <input type="hidden" name="cid" value="{{ cid }}">
-              <input type="hidden" name="tid" value="{{ channel_tag.id }}">
-              {# <button type="submit">x</button> #}
-              <button type="submit" class="tag-delete-btn"></button>
-            </form>
+            {% if uid == channel.uid %}
+              <form class="ch-tag-delete-btn" action="/delete_tag_link" method="POST">
+                <input type="hidden" name="cid" value="{{ cid }}">
+                <input type="hidden" name="tid" value="{{ channel_tag.id }}">
+                <button type="submit" class="tag-delete-btn"></button>
+              </form>
+            {% endif %}
           </div>
           {% endfor %}
         {% endif %}

--- a/templates/modal/delete-confirmation.html
+++ b/templates/modal/delete-confirmation.html
@@ -13,7 +13,7 @@
           <input type="submit" value="削除">
         </form>
         #}
-        {# <button id="delete-channel-confirmation-btn">削除</button> #}
+        <button id="delete-channel-confirmation-btn">削除</button>
       </a>
     </div>
   </div>

--- a/templates/modal/delete-confirmation.html
+++ b/templates/modal/delete-confirmation.html
@@ -8,7 +8,12 @@
       <p>削除ボタンを押すとチャンネルが消えます</p>
       <p>本当によろしいですか？</p>
       <a id="delete-confirm-link">
-        <button id="delete-channel-confirmation-btn">削除</button>
+        {#
+        <form action="/delete/{{ channel.id }}" method="GET">
+          <input type="submit" value="削除">
+        </form>
+        #}
+        {# <button id="delete-channel-confirmation-btn">削除</button> #}
       </a>
     </div>
   </div>


### PR DESCRIPTION
@dan-k4 

[目的]
チャット画面ヘッダー部の見栄え、機能の細部を調整

[実装の概要]
- チャンネル編集、削除機能の実装
- 紐付きタグ一覧のCSS調整

[レビューして欲しいところ]
- チャンネル編集、削除、タグ追加、タグ削除は正常に機能するか

[不安に思っていること]
- 特になし

[保留してること]
- タグをクリックしてもタグに紐づいたチャンネル一覧へは遷移せずTypeErrorが発生する（ローカルの環境が古い可能性を疑い、一旦プルリクして最新版をpullして確認したいです）
- モーダル表示時に紐付きタグ一覧のヘッダー表示が残ってしまう（原因不明のため時間があれば修正としたい）

[関連]
- 特になし

close #111 