### PR TITLE
チャンネル機能・タグ機能の改修とタグ選択時の不具合修正

### DIFF
--- a/app.py
+++ b/app.py
@@ -196,6 +196,10 @@ def add_channel():
     """チャンネル名
 
     フォームからチャンネル名を取得→channel_nameへ代入
+
+    if チャンネル名が入力されていない場合:
+        エラーページを表示
+
     データベースから、入力されたチャンネル名と同じチャンネルを取得→channelへ代入
 
     if チャンネル名がデータベースに存在しない場合:
@@ -207,6 +211,11 @@ def add_channel():
         エラーページを表示
     """
     channel_name = request.form.get('channel-title')
+
+    if not channel_name:
+        error = 'チャンネル名が入力されていません'
+        return render_template('error/error.html', error_message=error)
+
     channel = dbConnect.getChannelByName(channel_name)
 
     if channel == None:
@@ -233,6 +242,10 @@ def update_channel():
 
     フォームからチャンネルIDを取得→cidに代入
     フォームからチャンネル名を取得→channel_nameに代入
+
+    if チャンネル名が入力されていない場合:
+        エラーページを表示
+
     フォームからチャンネル説明文を取得→channel_descriptionに代入
 
     データベースの（ユーザーID、チャンネル名、チャンネル説明文、チャンネルID）を更新
@@ -241,6 +254,11 @@ def update_channel():
 
     cid = request.form.get('cid')
     channel_name = request.form.get('channel-title')
+
+    if not channel_name:
+        error = 'チャンネル名が入力されていません'
+        return render_template('error/error.html', error_message=error)
+
     channel_description = request.form.get('channel-description')
 
     dbConnect.updateChannel(uid, channel_name, channel_description, cid)
@@ -306,6 +324,7 @@ def delete_channel(cid):
             """
         else:
             dbConnect.deleteChannel(cid)
+            dbConnect.deleteTagLinkByChannelId(cid)
             return redirect('/')
 
 # メッセージ作成機能
@@ -410,12 +429,13 @@ def tag_channel(tid):
         「まだチャンネルは登録されていません」と表示
         ※redirectでindexに遷移すると、tag_nameの表示が消えてしまうためrender_templateで記述
     """
+    tags = []
     tag = dbConnect.getTagById(tid)
     tag_name = tag['name']
     channels = dbConnect.getChannelsByTagId(tid)
 
     if channels:
-        return render_template('index.html', tag_name=tag_name, channels=channels, uid=uid)
+        return render_template('index.html',tags=tags, tag_name=tag_name, channels=channels, uid=uid)
     else:
         flash(tag_name + 'のタグにチャンネルは登録されていません')
         return redirect('/tags')
@@ -435,6 +455,8 @@ def link_tag():
 
     """
     フォームからタグ名を取得→tag_nameへ代入
+    if タグ名が入力されていない場合:
+        エラーページへ遷移
     フォームからチャンネルIDを取得→cidへ代入
 
     データベースから入力されたタグ名と同じデータを取り出す→tagへ代入
@@ -458,6 +480,11 @@ def link_tag():
     """
 
     tag_name = request.form.get('tag_name')
+
+    if not tag_name:
+        error = 'タグ名が入力されていません'
+        return render_template('error/error.html', error_message=error)
+
     cid = request.form.get('cid')
 
     tag = dbConnect.getTagByName(tag_name)

--- a/models.py
+++ b/models.py
@@ -566,3 +566,26 @@ class dbConnect:
         # 最終処理：カーソルを閉じる
         finally:
             cur.close()
+
+    # チャンネル削除時に選択されたチャンネルのタグの紐付けを全て削除
+    def deleteTagLinkByChannelId(cid):
+        """
+        MySQLにDBクラスで定義した接続用メソッドを使用して接続
+        カーソルを作成→curへ代入
+        channels_tagsテーブルから渡ってきたチャンネルIDのカラムを削除
+        execute文でsqlを実行
+        commitで変更を確定
+        """
+        try:
+            conn = DB.getConnection()
+            cur = conn.cursor()
+            sql = 'DELETE FROM channels_tags WHERE cid=%s;'
+            cur.execute(sql, (cid))
+            conn.commit()
+        # 例外処理
+        except Exception as e:
+            print(e + 'が発生しています')
+            return None
+        # 最終処理：カーソルを閉じる
+        finally:
+            cur.close()

--- a/templates/index.html
+++ b/templates/index.html
@@ -9,6 +9,9 @@
       <div class="channel-title">
         <h1>チャンネル一覧</h1>
       </div>
+      {% if tag_name %}
+      <h2>タグ名:{{ tag_name }}</h2>
+      {% endif %}
       <div class="channel-all">
         <a href="{{ url_for('index') }}">全チャンネル表示</a>
       </div>


### PR DESCRIPTION
[目的]
- チャンネル名が入力されていなくても、作成・編集できてしまう不具合の調整
- タグ名が入力されていなくても、作成できてしまう不具合の調整

[実装の概要]
- app.py内のadd_channel, update_channel
    - チャンネル名が入力されていない場合エラーページへ遷移
- delete_channel関数
    - チャンネル削除時に、チャンネルとタグの紐付けが残ってしまう不具合修正
- tag_channel関数
    - タグ選択時、チャンネル一覧画面でエラーになる不具合修正  

[レビューして欲しいところ]
- 実際に動作させてみてエラーは起きないか
- コードに間違いはないか

[不安に思っていること]
- タグ関連でまたエラーとか起きそうで怖い

[保留してること]
- メッセージ削除を投稿した本人しかできない様にする
- 追加したかったけど、一旦このままプルリクしてます

[関連]

close #119 